### PR TITLE
Add GitHub links to frameworks on about page

### DIFF
--- a/pages/about.php
+++ b/pages/about.php
@@ -32,7 +32,7 @@
 </section>
 <hr aria-hidden="true">
 <section class="about">
-	<p>I&ZeroWidthSpace;'m a full-stack web developer from Sweden, currently working as IT-Lead at <a href="https://icellate.com">iCellate&nbsp;Medical</a> in Solna, Stockholm - a biopharma start-up developing precision oncology. I develop and maintain <a href="https://docs.vlw.one/vegvisir">my own web framework</a> and use it to build web apps and websites - including this one.</p>
+	<p>I&ZeroWidthSpace;'m a full-stack web developer from Sweden, currently working as IT-Lead at <a href="https://icellate.com">iCellate&nbsp;Medical</a> in Solna, Stockholm - a biopharma start-up developing precision oncology. I develop and maintain <a href="https://github.com/VictorWesterlund/vegvisir">my own web framework</a> and use it to build web apps and websites - including this one.</p>
 	<p>The &lt;programming/markup/command&gt;-languages I currently use the most are (in a mostly accurate decending order): PHP, JavaScript, CSS, MySQL, Python, SQLite, Bash, and [raw] HTML. In the process of learning Rust!</p>
 </section>
 <section class="about">
@@ -42,8 +42,8 @@
 <section class="about">
 	<h2>Projects</h2>
 	<p>These are my top projects I'm working on right now:</p>
-	<p>* <a href="">Vegvisir</a>: A web framework written in PHP, for PHP developers.</p>
-	<p>* <a href="">Reflect</a>: An API framework also written in PHP, for PHP developers.</p>
+	<p>* <a href="https://github.com/VictorWesterlund/vegvisir">Vegvisir</a>: A web framework written in PHP, for PHP developers.</p>
+	<p>* <a href="https://github.com/VictorWesterlund/reflect">Reflect</a>: An API framework also written in PHP, for PHP developers.</p>
 	<p>See more on my <a href="work" vv="about" vv-call="navigate">works page</a>. And even more including smaller projects on my <a href="https://github.com/VictorWesterlund">GitHub</a>.</p>
 </section>
 <section class="about">


### PR DESCRIPTION
Replaced a link to a soon-to-be-created docs page for Vegvisir (and Reflect) with a link to its GitHub page until this page has been written.

Also added some missing links to GitHub!