### PR TITLE
Portable `target="blank"` unicode arrow

### DIFF
--- a/assets/css/document.css
+++ b/assets/css/document.css
@@ -91,7 +91,7 @@ a > button::after {
 
 a[target="_blank"] > button::after,
 :is(h1, h2, h3, p, li) > a[target="_blank"]::after {
-	content: " ⮥";
+	content: " ↑";
 	color: var(--color-accent);
 	white-space: nowrap;
 }


### PR DESCRIPTION
Closes #11 

Tried several unicode arrows that I think would have looked better

- "⤴" Same issues as addressed in the issue in some browsers, and an emoji in other browsers
- "ᛏ" Looks great on all browsers tested except Safari, where the icon is wide as f* and pixelated
- "↗" An emoji in Safari

I don't want emojis since I can't control their color.

I've settled for "↑" for now since it looks alright in most browsers, and looks great in Safari! Will open a separate (low-priority) to hunt for a better symbol