### PR TITLE
Remove unused querySelector from index page JS

### DIFF
--- a/assets/js/pages/index.js
+++ b/assets/js/pages/index.js
@@ -106,15 +106,3 @@ if (window.matchMedia("(hover: hover)")) {
 	// Reset color on navigation
 	document.querySelector(vv._env.MAIN).addEventListener(vv.Navigation.events.LOADED, () => updateColor(), { once: true });
 }
-
-// Open search box from mobile fullscreen menu
-{
-	// Open search dialog when searchbox is clicked
-	document.querySelector("menu searchbox").addEventListener("click", () => {
-		// Search box dialog element
-		document.querySelector("dialog.search").showModal();
-
-		// Close fullscreen menu
-		document.querySelector("menu").classList.remove("active");
-	});
-}


### PR DESCRIPTION
This PR removes some unused JS from the index page. This is a leftover from an earlier pre-1.0 version of this site