### PR TITLE
Bump reflect@2.7.0 confirmed compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This website is built for PHP 8.0+ and MariaDB 14+ (for the API database).
 **Confimed supported framework versions:**
 Vegvisir|Reflect
 --|--
-✅ [`2.4.3`](https://github.com/VictorWesterlund/vegvisir/releases/tag/2.4.3)|✅ [`2.6.3`](https://github.com/VictorWesterlund/reflect/releases/tag/2.6.3)
+✅ [`2.4.3`](https://github.com/VictorWesterlund/vegvisir/releases/tag/2.4.3)|✅ [`2.7.0`](https://github.com/VictorWesterlund/reflect/releases/tag/2.7.0)
 
 ## Website (Vegvisir)
 1. **Download this repo**


### PR DESCRIPTION
Bump confirmed compatability with [Reflect 2.7.0](https://github.com/VictorWesterlund/reflect/releases/tag/2.7.0)