### PR TITLE
Fix timezone offset for Sweden on contact page

### DIFF
--- a/.env.example.ini
+++ b/.env.example.ini
@@ -2,3 +2,6 @@
 base_url    = "https://api.vlw.one/"
 api_key     = ""
 verify_peer = 0
+
+[time]
+date_time_zone = "Europe/Stockholm"

--- a/pages/contact.php
+++ b/pages/contact.php
@@ -15,7 +15,7 @@
 <style><?= VV::css("pages/contact") ?></style>
 <section>
 	<h1>Let's chat</h1>
-	<p>The best way to get in touch is by email, or with the form on this page. I will try to reply as quickly as possible, probably within a few hours. The time is <i><?= date("h:i a") ?></i> in Sweden right now.</p>
+	<p>The best way to get in touch is by email, or with the form on this page. I will try to reply as quickly as possible, probably within a few hours. The time is <i><?= (new DateTime("now", new DateTimeZone($_ENV["time"]["date_time_zone"])))->format("h:i a") ?></i> in Sweden right now.</p>
 </section>
 <section class="social">
 	<a href="mailto:victor@vlw.se"><social>


### PR DESCRIPTION
This PR adds a new envvar for a `DateTimeZone` string which will be used to show the local time on the contact page. And potentially other places in the future.