### PR TITLE
Bump compatability with Vegvisir 2.4.4 and Reflect 2.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This website is built for PHP 8.0+ and MariaDB 14+ (for the API database).
 **Confimed supported framework versions:**
 Vegvisir|Reflect
 --|--
-✅ [`2.4.3`](https://github.com/VictorWesterlund/vegvisir/releases/tag/2.4.3)|✅ [`2.7.0`](https://github.com/VictorWesterlund/reflect/releases/tag/2.7.0)
+✅ [`2.4.4`](https://github.com/VictorWesterlund/vegvisir/releases/tag/2.4.4)|✅ [`2.7.1`](https://github.com/VictorWesterlund/reflect/releases/tag/2.7.1)
 
 ## Website (Vegvisir)
 1. **Download this repo**


### PR DESCRIPTION
Bump compatability with [`Vegvisir@2.4.4`](https://github.com/VictorWesterlund/vegvisir/releases/tag/2.4.4) and [`Reflect 2.7.1`](https://github.com/VictorWesterlund/reflect/releases/tag/2.7.1)