### PR TITLE
Add alt text for gazing.jpg on index page

### DIFF
--- a/pages/index.php
+++ b/pages/index.php
@@ -22,10 +22,5 @@
 	</button>
 </div>
 
-<img src="/assets/media/gazing.jpg"/>
-<!--<picture class="gazing">
-	<source srcset="/assets/media/gazing.avif" type="image/avif"/>
-	<source srcset="/assets/media/gazing.webp" type="image/webp"/>
-	<img src="/assets/media/gazing.jpg"/>
-</picture>-->
+<img src="/assets/media/gazing.jpg" alt="A portrait of Victor with a pair of cartoon glasses drawn in the shape of two V's over his eyes"/>
 <script><?= VV::js("pages/index") ?></script>


### PR DESCRIPTION
This PR adds an `alt` text for the "gazing" image on the index page.

It also removes an unused `<picture>` element that I might add back in the future.